### PR TITLE
Extended symlink_shared task for users who doesn't need mysql.rb

### DIFF
--- a/lib/uberspacify/base.rb
+++ b/lib/uberspacify/base.rb
@@ -71,7 +71,7 @@ exec multilog t ./main
       put log_script,     "#{fetch :home}/etc/run-rails-#{fetch :application}/log/run"
       run                 "chmod +x #{fetch :home}/etc/run-rails-#{fetch :application}/run"
       run                 "chmod +x #{fetch :home}/etc/run-rails-#{fetch :application}/log/run"
-      run                 "ln -nfs #{fetch :home}/etc/run-rails-#{fetch :application} #{fetch :home}/service/rails-#{fetch :application}"
+      run                 "ln -nfs #{fetch :home}/etc/run-rails-#{fetch :application} #{fetch :home}/service/rails-#{fetch :application}"          
 
     end
   end
@@ -100,6 +100,7 @@ RewriteRule ^(.*)$ http://localhost:#{fetch :passenger_port}/$1 [P]
     end
 
     task :symlink_shared do
+      run "mkdir -p #{fetch :shared_path}/config" 
       run "ln -nfs #{shared_path}/config/database.yml #{release_path}/config/database.yml"
     end
   end

--- a/lib/uberspacify/base.rb
+++ b/lib/uberspacify/base.rb
@@ -101,6 +101,7 @@ RewriteRule ^(.*)$ http://localhost:#{fetch :passenger_port}/$1 [P]
 
     task :symlink_shared do
       run "mkdir -p #{fetch :shared_path}/config" 
+      put config.to_yaml, "#{fetch :shared_path}/config/database.yml"      
       run "ln -nfs #{shared_path}/config/database.yml #{release_path}/config/database.yml"
     end
   end

--- a/lib/uberspacify/base.rb
+++ b/lib/uberspacify/base.rb
@@ -1,11 +1,11 @@
-require 'capistrano_colors'    
+require 'capistrano_colors'
 require 'rvm/capistrano'
 require 'bundler/capistrano'
 
 def abort_red(msg)
-  abort "  * \e[#{1};31mERROR: #{msg}\e[0m" 
+  abort "  * \e[#{1};31mERROR: #{msg}\e[0m"
 end
-  
+
 Capistrano::Configuration.instance.load do
 
   # required variables
@@ -15,7 +15,7 @@ Capistrano::Configuration.instance.load do
   # optional variables
   _cset(:domain)                { nil }
   _cset(:passenger_port)        { rand(61000-32768+1)+32768 } # random ephemeral port
-  
+
   _cset(:deploy_via)            { :remote_cache }
   _cset(:git_enable_submodules) { 1 }
   _cset(:branch)                { 'master' }
@@ -28,7 +28,7 @@ Capistrano::Configuration.instance.load do
   set(:use_sudo)                { false }
   set(:rvm_type)                { :user }
   set(:rvm_install_ruby)        { :install }
-  set(:rvm_ruby_string)         { "ree@rails-#{application}" } 
+  set(:rvm_ruby_string)         { "ree@rails-#{application}" }
 
   ssh_options[:forward_agent] = true
   default_run_options[:pty]   = true
@@ -48,7 +48,7 @@ Capistrano::Configuration.instance.load do
       run 'uberspace-setup-svscan ; echo 0'
     end
   end
-  
+
   namespace :daemontools do
     task :setup_daemon do
       daemon_script = <<-EOF
@@ -71,7 +71,7 @@ exec multilog t ./main
       put log_script,     "#{fetch :home}/etc/run-rails-#{fetch :application}/log/run"
       run                 "chmod +x #{fetch :home}/etc/run-rails-#{fetch :application}/run"
       run                 "chmod +x #{fetch :home}/etc/run-rails-#{fetch :application}/log/run"
-      run                 "ln -nfs #{fetch :home}/etc/run-rails-#{fetch :application} #{fetch :home}/service/rails-#{fetch :application}"          
+      run                 "ln -nfs #{fetch :home}/etc/run-rails-#{fetch :application} #{fetch :home}/service/rails-#{fetch :application}"
 
     end
   end
@@ -83,7 +83,7 @@ RewriteEngine On
 RewriteRule ^(.*)$ http://localhost:#{fetch :passenger_port}/$1 [P]
       EOF
       path = fetch(:domain) ? "/var/www/virtual/#{fetch :user}/#{fetch :domain}" : "#{fetch :home}/html"
-      run                 "mkdir -p #{path}"	
+      run                 "mkdir -p #{path}"
       put htaccess,       "#{path}/.htaccess"
     end
   end
@@ -100,8 +100,6 @@ RewriteRule ^(.*)$ http://localhost:#{fetch :passenger_port}/$1 [P]
     end
 
     task :symlink_shared do
-      run "mkdir -p #{fetch :shared_path}/config" 
-      run "mv #{fetch :deploy_to}/current/config/database.yml #{fetch :shared_path}/config/database.yml"
       run "ln -nfs #{shared_path}/config/database.yml #{release_path}/config/database.yml"
     end
   end

--- a/lib/uberspacify/base.rb
+++ b/lib/uberspacify/base.rb
@@ -83,7 +83,7 @@ RewriteEngine On
 RewriteRule ^(.*)$ http://localhost:#{fetch :passenger_port}/$1 [P]
       EOF
       path = fetch(:domain) ? "/var/www/virtual/#{fetch :user}/#{fetch :domain}" : "#{fetch :home}/html"
-      run                 "mkdir -p #{path}"
+      run                 "mkdir -p #{path}"	
       put htaccess,       "#{path}/.htaccess"
     end
   end
@@ -101,7 +101,7 @@ RewriteRule ^(.*)$ http://localhost:#{fetch :passenger_port}/$1 [P]
 
     task :symlink_shared do
       run "mkdir -p #{fetch :shared_path}/config" 
-      put config.to_yaml, "#{fetch :shared_path}/config/database.yml"      
+      run "mv #{fetch :deploy_to}/current/config/database.yml #{fetch :shared_path}/config/database.yml"
       run "ln -nfs #{shared_path}/config/database.yml #{release_path}/config/database.yml"
     end
   end

--- a/lib/uberspacify/database/mysql.rb
+++ b/lib/uberspacify/database/mysql.rb
@@ -9,14 +9,14 @@ Capistrano::Configuration.instance.load do
       my_cnf = capture('cat ~/.my.cnf')
       config = {}
       %w(development production test).each do |env|
-        
+
         config[env] = {
-          'adapter' => 'mysql2',
-          'encoding' => 'utf8',
-          'database' => "#{fetch :user}_rails_#{fetch :application}_#{env}",
-          'host' => 'localhost'
+            'adapter' => 'mysql2',
+            'encoding' => 'utf8',
+            'database' => "#{fetch :user}_rails_#{fetch :application}_#{env}",
+            'host' => 'localhost'
         }
-        
+
         my_cnf.match(/^user=(\w+)/)
         config[env]['username'] = $1
 
@@ -25,10 +25,13 @@ Capistrano::Configuration.instance.load do
 
         my_cnf.match(/^port=(\d+)/)
         config[env]['port'] = $1.to_i
-        
+
         run "mysql -e 'CREATE DATABASE IF NOT EXISTS #{config[env]['database']} CHARACTER SET utf8 COLLATE utf8_general_ci;'"
       end
-      
+
+      run "mkdir -p #{fetch :shared_path}/config"
+      put config.to_yaml, "#{fetch :shared_path}/config/database.yml"
+
     end
   end
 

--- a/lib/uberspacify/database/sqlite.rb
+++ b/lib/uberspacify/database/sqlite.rb
@@ -1,0 +1,14 @@
+Capistrano::Configuration.instance.load do
+
+  # callbacks
+  after   'deploy:setup',       'sqlite:copy_database_files'
+
+  # custom recipes
+  namespace :sqlite do
+    task :copy_database_files do
+      run "mkdir -p #{fetch :shared_path}/config"
+      run "mv #{fetch :deploy_to}/current/config/database.yml #{fetch :shared_path}/config/database.yml"
+    end
+  end
+
+end

--- a/lib/uberspacify/mysql.rb
+++ b/lib/uberspacify/mysql.rb
@@ -29,7 +29,6 @@ Capistrano::Configuration.instance.load do
         run "mysql -e 'CREATE DATABASE IF NOT EXISTS #{config[env]['database']} CHARACTER SET utf8 COLLATE utf8_general_ci;'"
       end
       
-      run "mkdir -p #{fetch :shared_path}/config"
       put config.to_yaml, "#{fetch :shared_path}/config/database.yml"
       
     end

--- a/lib/uberspacify/mysql.rb
+++ b/lib/uberspacify/mysql.rb
@@ -29,8 +29,6 @@ Capistrano::Configuration.instance.load do
         run "mysql -e 'CREATE DATABASE IF NOT EXISTS #{config[env]['database']} CHARACTER SET utf8 COLLATE utf8_general_ci;'"
       end
       
-      put config.to_yaml, "#{fetch :shared_path}/config/database.yml"
-      
     end
   end
 

--- a/lib/uberspacify/recipes.rb
+++ b/lib/uberspacify/recipes.rb
@@ -1,2 +1,3 @@
 require 'uberspacify/base'
-require 'uberspacify/mysql'
+require 'uberspacify/database/mysql'
+require 'uberspacify/database/sqlite'


### PR DESCRIPTION
I added a seperate sqlite.rb, cause users who doesn't need mysql.rb will get errors when executing

```
bundle exec cap deploy:migrations
```

cause symlinks cannot be done if the target directoy doesn't exists.
Users can now chose between sqlite and mysql at the deploy.rb

```
# chose your database by commenting
# require 'uberspacify/database/mysql'
require 'uberspacify/database/sqlite'
```
