### PR TITLE
Add support for mongoDB

### DIFF
--- a/lib/uberspacify/mongodb.rb
+++ b/lib/uberspacify/mongodb.rb
@@ -13,7 +13,6 @@ Capistrano::Configuration.instance.load do
         # set up mongo db and capture admin access information
         admin_access = capture('uberspace-setup-mongodb | grep Portnum# -A 2')
         config = {}
-        run("echo #{admin_access}")
         config[:password] = admin_access[/Password:.+/]['Password: '.length..-2] # cut the \r that is captured at end of line
         #config[:password] = admin_access[/Password:.+/]['Password: '.length..-1]
         config[:port] = Integer(admin_access[/[0-9]{5}/]) 

--- a/lib/uberspacify/mongodb.rb
+++ b/lib/uberspacify/mongodb.rb
@@ -1,0 +1,51 @@
+Capistrano::Configuration.instance.load do
+
+  # callbacks
+  after   'deploy:setup',       'mongo:setup_database_and_config'
+  after   'deploy',             'mongo:configure_project_for_database'
+
+  set(:mongoid_path) { "#{fetch :home}/mongoid.yml" }
+  # custom recipes
+  namespace :mongo do
+    task :setup_database_and_config do
+      # ensure that mongo is not already set up
+      unless capture("if [ -e '#{fetch :mongoid_path}' ]; then echo -n 'true'; fi") == 'true'
+        # set up mongo db and capture admin access information
+        admin_access = capture('uberspace-setup-mongodb | grep Portnum# -A 2')
+        config = {}
+        run("echo #{admin_access}")
+        config[:password] = admin_access[/Password:.+/]['Password: '.length..-2] # cut the \r that is captured at end of line
+        #config[:password] = admin_access[/Password:.+/]['Password: '.length..-1]
+        config[:port] = Integer(admin_access[/[0-9]{5}/]) 
+        config[:user] = admin_access[/\S+_mongoadmin/]
+        # generate a db user password and the db user
+        user_password = (0...8).map{ (('a'..'z').to_a+('A'..'Z').to_a)[rand(54)] }.join
+        run(
+          "mongo admin --port #{config[:port]}" +
+          " -u #{config[:user]}" +
+          " -p #{config[:password]}" +
+          " --eval \"db.getSiblingDB('pixel-to-go')" +
+          ".addUser({user:'locomotive'," +
+          "pwd:'#{user_password}'," +
+          "roles:['readWrite','dbAdmin']});\""
+        )
+        # write to $HOME/mongoid.yml
+        mongoid = {'production' => {'sessions' => {'default' => {} }}}
+        access_data = mongoid['production']['sessions']['default']
+        access_data['database'] = 'pixel-to-go'
+        access_data['hosts'] = ["localhost:#{config[:port]}"]
+        access_data['username'] = 'locomotive'
+        access_data['password'] = user_password
+        put mongoid.to_yaml, mongoid_path
+      end
+    end
+
+    task :configure_project_for_database do
+      if capture("if [ -e '#{fetch :mongoid_path}' ]; then echo -n 'true'; fi") == 'true'
+        run("cp #{fetch :mongoid_path} #{fetch :deploy_to}/current/config/mongoid.yml")
+      end
+    end
+  
+  end
+
+end


### PR DESCRIPTION
Not perfect, but as long as output of mongodb setup at uberspace remains the same, it should work!
I added both a callback for deploy:setup, so that mongodb is installed and the access data is saved in the user's home directory and a callback for deploy, so that the configuration is copied to the project config.
